### PR TITLE
feat: add skkeleton-vim with denops-vim for SKK input

### DIFF
--- a/home-manager/install-package/neovim.nix
+++ b/home-manager/install-package/neovim.nix
@@ -13,6 +13,25 @@
       clipboard = "unnamedplus";
     };
 
+    extraPlugins = with pkgs.vimPlugins; [
+      skkkeleton-vim
+      denops-vim
+    ];
+
+    extraConfigLua = ''
+      vim.g['skkeleton#config'] = {
+        globalDictionaries = { '${pkgs.skk-dicts}/share/skk/SKK-JISYO.L' },
+        eggLikeNewline = true,
+      }
+      vim.fn['skkeleton#register_keymap']('input', { ['l'] = 'disable' })
+    '';
+
+    extraConfigVim = ''
+      " skkeleton: C-jで起動
+      imap <C-j> <Plug>(skkeleton-enable)
+      cmap <C-j> <Plug>(skkeleton-enable)
+    '';
+
     plugins = {
       web-devicons.enable = true;
       which-key.enable = true;


### PR DESCRIPTION
## Summary

- NeovimにSKK入力（skkeleton）を導入

## Changes

- 
  -  +  を  に追加
  - SKK-JISYO.L 辞書を  パッケージから参照
  - キーマップ設定:
    -  → skkeleton起動 (insert/cmdline mode)
    -  → skkeleton停止 (input mode)