### PR TITLE
refactor: use nixvim native definitions for skkeleton keymaps and config

### DIFF
--- a/home-manager/install-package/neovim.nix
+++ b/home-manager/install-package/neovim.nix
@@ -13,26 +13,15 @@
       clipboard = "unnamedplus";
     };
 
-    extraPlugins = with pkgs.vimPlugins; [
-      skkkeleton-vim
-      denops-vim
-    ];
-
-    extraConfigLua = ''
-      vim.g['skkeleton#config'] = {
-        globalDictionaries = { '${pkgs.skk-dicts}/share/skk/SKK-JISYO.L' },
-        eggLikeNewline = true,
-      }
-      vim.fn['skkeleton#register_keymap']('input', { ['l'] = 'disable' })
-    '';
-
-    extraConfigVim = ''
-      " skkeleton: C-jで起動
-      imap <C-j> <Plug>(skkeleton-enable)
-      cmap <C-j> <Plug>(skkeleton-enable)
-    '';
-
     plugins = {
+      skkeleton = {
+        enable = true;
+        settings = {
+          globalDictionaries = [ "${pkgs.skk-dicts}/share/skk/SKK-JISYO.L" ];
+          eggLikeNewline = true;
+        };
+      };
+
       web-devicons.enable = true;
       which-key.enable = true;
       bufferline.enable = true;
@@ -89,6 +78,14 @@
         action = "<cmd>lua require('fff').find_files()<CR>";
         options = {
           desc = "FFF: find files";
+        };
+      }
+      {
+        mode = ["i" "c"];
+        key = "<C-j>";
+        action = "<Plug>(skkeleton-enable)";
+        options = {
+          desc = "SKK: skkeletonを起動";
         };
       }
     ];

--- a/home-manager/install-package/neovim.nix
+++ b/home-manager/install-package/neovim.nix
@@ -13,6 +13,25 @@
       clipboard = "unnamedplus";
     };
 
+    extraPlugins = with pkgs.vimPlugins; [
+      skkkeleton-vim
+      denops-vim
+    ];
+
+    extraConfigLua = ''
+      vim.g['skkeleton#config'] = {
+        globalDictionaries = { '${pkgs.skk-dicts}/share/skk/SKK-JISYO.L' },
+        eggLikeNewline = true,
+      }
+      vim.fn['skkeleton#register_keymap']('input', { ['l'] = 'disable' })
+    '';
+
+    extraConfigVim = ''
+      " skkeleton: C-jで起動
+      imap <C-j> <Plug>(skkeleton-enable)
+      cmap <C-j> <Plug>(skkeleton-enable)
+    '';
+
     plugins = {
       web-devicons.enable = true;
       which-key.enable = true;


### PR DESCRIPTION
Closes #22

## Changes
- Removed extraPlugins, extraConfigLua, extraConfigVim
- Added plugins.skkeleton with native settings (nixvim auto-resolves denops-vim dependency)
- Moved C-j keymaps to keymaps array with multi-mode (which-key shows desc)

## Note
- skkeleton#register_keymap call was removed. Add back if needed.