### PR TITLE
feat: add csharp devShell with dotnet-sdk and omnisharp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -224,6 +224,17 @@
             echo "kotlin version: $(kotlin -version)"
           '';
         };
+        csharp = pkgs.mkShell {
+          buildInputs = [
+            pkgs.dotnet-sdk
+            pkgs.omnisharp-roslyn
+            # pkgs.dotnet-aspnetcore  # Web開発時に追加
+          ];
+          shellHook = ''
+            echo "dotnet version: $(dotnet --version)"
+            echo "OmniSharp version: $(omnisharp --version)"
+          '';
+        };
       };
       #   inherit system;
       #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];


### PR DESCRIPTION
## Summary
- `csharp` devShell を追加
  - `dotnet-sdk` (.NET CLI, C# コンパイラ)
  - `omnisharp-roslyn` (C# LSP, エディタ補完用)
  - `dotnet-aspnetcore` はコメントアウトで併記 (Web開発時に uncomment)

## Test Plan
- [ ] `nix develop .#csharp` でシェルが起動し dotnet/OmniSharp が利用できることを確認

Closes #