### PR TITLE
feat: add takt to Home Manager via flake input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    takt = {
+      url = "github:nrslib/takt";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # 実行時に --override-input で差し替える
     local-options = {
       url = "path:./user-options/options.nix";

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -18,6 +18,7 @@ let
   zed = import ./install-package/zed.nix { inherit pkgs; inherit isDesktop; };
   nix-vim-package = import ./install-package/neovim.nix { inherit pkgs; };
   fish-package = import ./install-package/fish.nix { inherit pkgs; };
+  takt-package = import ./install-package/takt.nix { inherit inputs; inherit pkgs; };
 in
 {
   imports = [
@@ -25,6 +26,7 @@ in
     nixvim.homeModules.nixvim
     nix-vim-package
     fish-package
+    takt-package
   ];
 
   nixpkgs = {

--- a/home-manager/install-package/takt.nix
+++ b/home-manager/install-package/takt.nix
@@ -1,0 +1,8 @@
+{ pkgs, inputs, ... }:
+
+{
+  home.packages = [
+    # Takt 本体。nixpkgs ではなく flake input から取得する
+    inputs.takt.packages.${pkgs.system}.default
+  ];
+}


### PR DESCRIPTION
## Summary
- `github:nrslib/takt` を flake input として追加 (`inputs.nixpkgs.follows`)
- `home-manager/install-package/takt.nix` にインストール定義を切り出し
- `default.nix` の imports に takt モジュールを追加

## Changes
| File | Change |
|------|--------|
| `flake.nix` | `takt` input を追加 |
| `home-manager/default.nix` | takt-package を import/imports に追加 |
| `home-manager/install-package/takt.nix` | 新規作成 (`inputs.takt.packages.\${system}.default`)|

## 方針
- overlay は使わず flake input から直接取得
- nixpkgs 未収録のため `pkgs.takt` は使わない

## Test Plan
- [ ] `home-manager switch --flake .#myHomeConfig` で適用し `takt --version` が通ることを確認