### PR TITLE
feat: modularize Home Manager shell integrations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,6 +250,7 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_2",
         "nixvim": "nixvim",
+        "takt": "takt",
         "vim-src": "vim-src"
       }
     },
@@ -280,6 +281,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "takt": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784759392,
+        "narHash": "sha256-oiasBugbXFzTvUBknYUpGUZv89X/0lqlDItFWwbOUIw=",
+        "owner": "nrslib",
+        "repo": "takt",
+        "rev": "3e450964642b1a678b61fab3750d3e3588739934",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nrslib",
+        "repo": "takt",
         "type": "github"
       }
     },

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -18,7 +18,7 @@ let
     else [];
   zed = import ./install-package/zed.nix { inherit pkgs; inherit isDesktop; };
   nix-vim-package = import ./install-package/neovim.nix { inherit pkgs; };
-  fish-package = import ./install-package/fish.nix { inherit pkgs; };
+  shell = import ./shell;
   takt-package = import ./install-package/takt.nix { inherit inputs; inherit pkgs; };
 in
 {
@@ -26,7 +26,7 @@ in
     zed
     nixvim.homeModules.nixvim
     nix-vim-package
-    fish-package
+    shell
     takt-package
   ];
 

--- a/home-manager/install-package/common.nix
+++ b/home-manager/install-package/common.nix
@@ -17,16 +17,11 @@
     bat
     bun
     ripgrep
-    zoxide
-    yazi
     pik
     just
     jq
     fd
-    fzf
-    direnv
     nushell
-    eza
     dust
     tmux
     bruno

--- a/home-manager/install-package/darwin.nix
+++ b/home-manager/install-package/darwin.nix
@@ -6,7 +6,6 @@
     lima
     skhd
     docker-credential-helpers
-    zsh-abbr
     filetree
     keifu
   ];

--- a/home-manager/install-package/integrations.nix
+++ b/home-manager/install-package/integrations.nix
@@ -1,0 +1,7 @@
+[
+  "direnv"
+  "eza"
+  "fzf"
+  "yazi"
+  "zoxide"
+]

--- a/home-manager/shell/attributes.nix
+++ b/home-manager/shell/attributes.nix
@@ -3,8 +3,24 @@
   shellIntegrationPrograms,
   ...
 }:
-{
-  programs = lib.genAttrs shellIntegrationPrograms (_: {
+let
+  generatedPrograms = lib.genAttrs shellIntegrationPrograms (_: {
     enable = true;
   });
+
+  programOverrides = {
+    direnv = {
+      nix-direnv.enable = true;
+    };
+
+    zoxide = {
+      options = [
+        "--cmd"
+        "ls"
+      ];
+    };
+  };
+in
+{
+  programs = lib.recursiveUpdate generatedPrograms programOverrides;
 }

--- a/home-manager/shell/attributes.nix
+++ b/home-manager/shell/attributes.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  shellIntegrationPrograms,
+  ...
+}:
+{
+  programs = lib.genAttrs shellIntegrationPrograms (_: {
+    enable = true;
+  });
+}

--- a/home-manager/shell/bash.nix
+++ b/home-manager/shell/bash.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  programs.bash = {
+    enable = true;
+  };
+}

--- a/home-manager/shell/bash.nix
+++ b/home-manager/shell/bash.nix
@@ -3,4 +3,8 @@
   programs.bash = {
     enable = true;
   };
+
+  # home-managerによる.bashrcの生成を無効化し、手動管理のファイルを維持する
+  home.file.".bashrc".enable = false;
+  home.file.".profile".enable = false;
 }

--- a/home-manager/shell/default.nix
+++ b/home-manager/shell/default.nix
@@ -1,0 +1,25 @@
+{ ... }:
+let
+  shellIntegrationPrograms = import ../install-package/integrations.nix;
+in
+{
+  _module.args = {
+    inherit shellIntegrationPrograms;
+  };
+
+  imports = [
+    ./attributes.nix
+    ./bash.nix
+    ./fish.nix
+    ./nushell.nix
+    ./zsh.nix
+  ];
+
+  home.shell = {
+    enableShellIntegration = true;
+    enableBashIntegration = true;
+    enableFishIntegration = true;
+    enableNushellIntegration = true;
+    enableZshIntegration = true;
+  };
+}

--- a/home-manager/shell/fish.nix
+++ b/home-manager/shell/fish.nix
@@ -3,7 +3,10 @@
   programs.fish = {
     enable = true;
     plugins = [
-      { name = "grc"; src = pkgs.fishPlugins.fzf-fish.src; }
+      {
+        name = "grc";
+        src = pkgs.fishPlugins.fzf-fish.src;
+      }
     ];
   };
 

--- a/home-manager/shell/nushell.nix
+++ b/home-manager/shell/nushell.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  programs.nushell = {
+    enable = true;
+  };
+}

--- a/home-manager/shell/nushell.nix
+++ b/home-manager/shell/nushell.nix
@@ -1,6 +1,12 @@
-{ ... }:
+{
+  config,
+  ...
+}:
 {
   programs.nushell = {
     enable = true;
+    # Home Managerの生成先
+    configDir =
+      "${config.xdg.configHome}/home-manager/nushell";
   };
 }

--- a/home-manager/shell/zsh.nix
+++ b/home-manager/shell/zsh.nix
@@ -1,7 +1,17 @@
-{ ... }:
+{ 
+  config,
+  lib,
+  ... 
+}:
+let
+  generatedZshDir = "${config.xdg.configHome}/home-manager/zsh";
+in
 {
   programs.zsh = {
     enable = true;
+
+    # Home Managerの生成先
+    dotDir = generatedZshDir;
 
     zsh-abbr = {
       enable = true;

--- a/home-manager/shell/zsh.nix
+++ b/home-manager/shell/zsh.nix
@@ -1,0 +1,15 @@
+{ ... }:
+{
+  programs.zsh = {
+    enable = true;
+
+    zsh-abbr = {
+      enable = true;
+      abbreviations = {
+        la = "ls -a";
+        ll = "ls -l";
+        lal = "ls -al";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add `home-manager/install-package/integrations.nix` as the single source of Shell Integration target programs
- Add `home-manager/shell/` modules for shell entrypoint, generated program attributes, and Bash/Fish/Nushell/Zsh-specific settings
- Generate `programs.<name>.enable = true` for direnv/eza/fzf/yazi/zoxide via `lib.genAttrs`
- Move existing Fish Home Manager config into `home-manager/shell/fish.nix`
- Remove integration-managed packages from `common.nix` and move zsh-abbr management into `programs.zsh.zsh-abbr`

## Validation
- `git diff --cached --check` passed before commit
- Confirmed pinned Home Manager rev contains modules/options for direnv, eza, fzf, yazi, zoxide, bash, fish, nushell, zsh, zsh-abbr, and `home.shell` integration options

## Not run
- `nix flake check` / Home Manager evaluation: `nix` is not installed in this execution environment
- `nixfmt-rfc-style`: formatter command is not installed in this execution environment