### PR TITLE
refactor: デスクトップ環境と利用アプリを分離

### DIFF
--- a/home-manager/desktop/hyprland.nix
+++ b/home-manager/desktop/hyprland.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+}:
+{
+  installPackages = with pkgs; [
+    # Hyprland
+    hyprlock
+    hypridle
+    hyprpaper
+    hyprpolkitagent
+    xdg-desktop-portal-hyprland
+    hyprpicker
+  ];
+}

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -4,7 +4,8 @@
 let
   desktop = (import ./desktop.nix { inherit pkgs; }).installPackages;
   multimedia = (import ./multimedia.nix { inherit pkgs; }).installPackages;
+  hyprland = (import ../desktop/hyprland.nix { inherit pkgs; }).installPackages;
 in
 {
-  installPackages = desktop ++ multimedia;
+  installPackages = desktop ++ multimedia ++ hyprland;
 }

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -20,39 +20,15 @@
     nemo
 
     # Wallpaper
-    hyprpaper
     waypaper
-
-    # Lock
-    hyprlock
-
-    # Idle
-    hypridle
-
-    # Notification
-    swaynotificationcenter
 
     # Status Bar
     waybar
 
-    # PolicyKit
-    hyprpolkitagent
-
-    # Portal
-    xdg-desktop-portal-hyprland
+    # Notification
+    swaynotificationcenter
 
     # Brightness
     brightnessctl
-
-    # Color Picker
-    hyprpicker
-
-    # Audio
-    pamixer
-    pavucontrol
-
-    # Screenshot
-    grimblast
-    satty
   ];
 }

--- a/home-manager/linux/multimedia.nix
+++ b/home-manager/linux/multimedia.nix
@@ -6,5 +6,13 @@
     # Recording
     gpu-screen-recorder
     obs-studio
+
+    # Screenshot
+    grimblast
+    satty
+
+    # Audio
+    pamixer
+    pavucontrol
   ];
 }


### PR DESCRIPTION
## Summary

デスクトップ環境依存パッケージとDE非依依アプリを分離し、DE切り替えを容易にする。

### 変更内容
- `desktop/hyprland.nix` を新設しHyprland依存パッケージを分離
- `linux/desktop.nix` はDE非依存のGUIアプリのみに整理
- `linux/multimedia.nix` に grimblast, satty, pamixer, pavucontrol を移動
- `linux/default.nix` で desktop + multimedia + hyprland を集約

### 分類方針

| ファイル | 対象 | 備考 |
|---------|------|------|
| `desktop/hyprland.nix` | hyprlock, hypridle, hyprpaper, hyprpolkitagent, xdg-desktop-portal-hyprland, hyprpicker | DE差し替え時にこのファイルを差し替えればOK |
| `linux/desktop.nix` | ghostty, vicinae, zen-browser, chromium, clipse, nemo, waypaper, waybar, swaync, brightnessctl | DE非依存 |
| `linux/multimedia.nix` | gpu-screen-recorder, obs-studio, grimblast, satty, pamixer, pavucontrol | DE非依存 |

## Test Plan
- [ ] `home-manager switch` が成功すること