### PR TITLE
feat: NixOS ホストモジュールを追加

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,15 @@ Home Manager による設定ファイル生成は極力行わない。
 ## ディレクトリ構成
 
 ```
+nixos/                          # NixOS ホスト設定（bare metal）
+├── configuration.nix           # エントリポイント
+├── hardware-configuration.nix  # インストーラー生成ファイル
+└── system/
+    ├── hardware.nix            # AMD CPU/GPU, Firmware, Bluetooth
+    ├── desktop.nix             # Hyprland, greetd, PipeWire, Locale, Fonts, Fcitx5
+    ├── services.nix            # NetworkManager, Firewall, Docker, Avahi
+    └── nix.nix                  # nix settings, GC, Store optimise
+
 home-manager/
 ├── default.nix              # エントリポイント。OS判定してパッケージを組み立て
 ├── desktop/
@@ -85,6 +94,45 @@ home-manager/
 │   └── darwin.nix            # macOS専用パッケージ
 └── shell/                    # シェル設定
 ```
+
+## NixOS モジュール責務
+
+### nix.nix
+
+Nix daemon の設定とメンテナンス。
+
+- `nix.settings` — experimental-features, trusted-users, substituters
+- `nix.gc` — 自動ガベージコレクション（weekly, 30d）
+- `nix.optimise` — 自動ストア最適化（weekly）
+
+### hardware.nix
+
+ハードウェアサポート。
+
+- AMD CPU Microcode, AMDGPU, Mesa（32bit含む）
+- 最新安定Kernel
+- Bluetooth, Redistributable Firmware
+
+### desktop.nix
+
+デスクトップ環境。デスクトップアプリは含めない。
+
+- Hyprland（system-wide enable）
+- greetd + tuigreet
+- PipeWire（ALSA/PulseAudio/JACK互換）
+- xdg.portal, polkit
+- Locale（ja_JP / en_US）, Timezone（Asia/Tokyo）
+- Fonts（Noto, Noto CJK, Noto Color Emoji, JetBrainsMono Nerd）
+- Fcitx5 + Mozc + SKK
+- xdg-user-dirs
+
+### services.nix
+
+OS基盤サービス。
+
+- NetworkManager, Firewall
+- Docker（rootless）
+- systemd-timesyncd, Avahi
 
 ## 実装ルール
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,53 @@
-個人用nixパッケージ管理リポジトリ
+個人用Nixパッケージ管理リポジトリ
 
-nix-darwin インストールコマンド
+NixOS + Home Manager + nix-darwin + chezmoi で Linux/macOS 環境を管理する。
+
+## 対象構成
+
+| 構成名 | 対象 | flake attribute |
+|--------|------|----------------|
+| nixos | Bare metal（単一ホスト） | `.#nixos` |
+| nixos-wsl | WSL2 on Windows | `.#nixos-wsl` |
+| mac-config | macOS（nix-darwin） | `.#mac-config` |
+| myHomeConfig | Home Manager 単体 | `.#myHomeConfig` |
+
+## NixOS (Bare Metal)
+
+```shell
+# ホスト構成の適用（初回 / 設定変更時）
+$ sudo nixos-rebuild switch --flake .#nixos
+
+# テスト（rebootせずに試す）
+$ sudo nixos-rebuild test --flake .#nixos
+
+# ビルドのみ（適用しない）
+$ nixos-rebuild build --flake .#nixos
+```
+
+`hardware-configuration.nix` はインストーラーが生成するファイルで置き換える。
+`isDesktop` は `user-options/options.nix` でホストごとに bool 値を切り替える。
+
+## NixOS (WSL2)
+
+```shell
+# WSL内で適用
+$ sudo nixos-rebuild switch --flake .#nixos-wsl
+```
+
+## nix-darwin (macOS)
+
 ```shell
 $ sudo nix run nix-darwin -- switch --flake .#mac-config
 ```
 
-home-manager インストールコマンド
+## Home Manager（単体）
+
 ```shell
-$  nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig --show-trace
+$ nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig --show-trace
 ```
 
-nixの容量削減
+## nixの容量削減
+
 ```shell
 $ nix-store --gc
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -108,13 +108,32 @@
           ];
         };
         nixosConfigurations = {
-          nixos = nixpkgs.lib.nixosSystem {
+          # WSL2 on Windows
+          nixos-wsl = nixpkgs.lib.nixosSystem {
             system = system;
             modules = [
               nixos-wsl.nixosModules.default
               {
                 system.stateVersion = "24.05";
                 wsl.enable = true;
+              }
+            ];
+          };
+          # Bare metal (single host)
+          nixos = nixpkgs.lib.nixosSystem {
+            system = system;
+            modules = [
+              ./nixos/configuration.nix
+              home-manager.nixosModules.home-manager
+              {
+                home-manager.users.himihiromu = import ./home-manager/default.nix {
+                  inherit inputs;
+                  inherit username;
+                  inherit pkgs;
+                  inherit system;
+                  inherit isDesktop;
+                  inherit nixvim;
+                };
               }
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -123,10 +123,11 @@
           nixos = nixpkgs.lib.nixosSystem {
             system = system;
             modules = [
+              { _module.args = { inherit username isDesktop; }; }
               ./nixos/configuration.nix
               home-manager.nixosModules.home-manager
               {
-                home-manager.users.himihiromu = import ./home-manager/default.nix {
+                home-manager.users.${username} = import ./home-manager/default.nix {
                   inherit inputs;
                   inherit username;
                   inherit pkgs;

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,0 +1,35 @@
+# NixOS Entry Point
+# 設定は極力書かず、エントリーポイントとして利用する
+
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ./system/hardware.nix
+    ./system/desktop.nix
+    ./system/services.nix
+    ./system/nix.nix
+  ];
+
+  # Hostname
+  networking.hostName = "nixos";
+
+  # User
+  users.users.himihiromu = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "docker"
+      "networkmanager"
+    ];
+  };
+
+  # Home Manager
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  system.stateVersion = "25.05";
+}

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,7 +1,7 @@
 # NixOS Entry Point
 # 設定は極力書かず、エントリーポイントとして利用する
 
-{ config, pkgs, ... }:
+{ config, pkgs, username, ... }:
 
 {
   imports = [
@@ -16,7 +16,7 @@
   networking.hostName = "nixos";
 
   # User
-  users.users.himihiromu = {
+  users.users.${username} = {
     isNormalUser = true;
     extraGroups = [
       "wheel"

--- a/nixos/hardware-configuration.nix
+++ b/nixos/hardware-configuration.nix
@@ -1,0 +1,8 @@
+# Dummy hardware-configuration.nix
+# インストーラー生成ファイルに置き換える
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+  boot.loader.grub.device = "/dev/sda";
+}

--- a/nixos/system/desktop.nix
+++ b/nixos/system/desktop.nix
@@ -1,0 +1,81 @@
+{ config, pkgs, ... }:
+
+{
+  # Hyprland
+  programs.hyprland = {
+    enable = true;
+    withXWAYLAND = true;
+  };
+
+  # Greetd + Tuigreet
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.greetd.tuigreet}/bin/tuigreet --time --remember --cmd Hyprland";
+        user = "greeter";
+      };
+    };
+  };
+
+  # PipeWire
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+    jack.enable = true;
+  };
+
+  # XDG Portal
+  xdg.portal.enable = true;
+
+  # PolicyKit
+  security.polkit.enable = true;
+
+  # Locale
+  i18n = {
+    defaultLocale = "ja_JP.UTF-8";
+    extraLocaleSettings = {
+      LC_ADDRESS = "ja_JP.UTF-8";
+      LC_IDENTIFICATION = "ja_JP.UTF-8";
+      LC_MEASUREMENT = "ja_JP.UTF-8";
+      LC_MONETARY = "ja_JP.UTF-8";
+      LC_NAME = "ja_JP.UTF-8";
+      LC_NUMERIC = "ja_JP.UTF-8";
+      LC_PAPER = "ja_JP.UTF-8";
+      LC_TELEPHONE = "ja_JP.UTF-8";
+      LC_TIME = "ja_JP.UTF-8";
+    };
+    supportedLocales = [
+      "ja_JP.UTF-8/UTF-8"
+      "en_US.UTF-8/UTF-8"
+    ];
+  };
+
+  # Timezone
+  time.timeZone = "Asia/Tokyo";
+
+  # Fonts
+  fonts.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-color-emoji
+    (nerdfonts.override { fonts = [ "JetBrainsMono" ]; })
+  ];
+
+  # Fcitx5 + Mozc + SKK
+  i18n.inputMethod = {
+    enabled = "fcitx5";
+    fcitx5.addons = with pkgs.fcitx5-with-addons; [
+      fcitx5-skk
+      fcitx5-mozc
+    ];
+  };
+
+  # XDG User Directories
+  xdg.userDirs = {
+    enable = true;
+    createGomeDirectories = true;
+  };
+}

--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+
+{
+  # AMD CPU Microcode
+  hardware.cpu.amd.updateMicrocode = true;
+
+  # AMDGPU
+  boot.initrd.kernelModules = [
+    "amdgpu"
+  ];
+
+  # Mesa / OpenGL
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
+
+  # Latest stable kernel
+  boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_12;
+
+  # Bluetooth
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+  };
+
+  # Redistributable Firmware
+  hardware.enableRedistributableFirmware = true;
+}

--- a/nixos/system/nix.nix
+++ b/nixos/system/nix.nix
@@ -1,0 +1,29 @@
+{ config, ... }:
+
+{
+  nix.settings = {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+
+    trusted-users = [
+      "@wheel"
+    ];
+
+    substituters = [
+      "https://cache.nixos.org"
+    ];
+  };
+
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+  };
+
+  nix.optimise = {
+    automatic = true;
+    dates = "weekly";
+  };
+}

--- a/nixos/system/nix.nix
+++ b/nixos/system/nix.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, username, ... }:
 
 {
   nix.settings = {
@@ -8,7 +8,7 @@
     ];
 
     trusted-users = [
-      "@wheel"
+      username
     ];
 
     substituters = [

--- a/nixos/system/services.nix
+++ b/nixos/system/services.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, ... }:
+
+{
+  # NetworkManager
+  networking.networkmanager.enable = true;
+
+  # Firewall
+  networking.firewall.enable = true;
+
+  # Docker
+  virtualisation.docker = {
+    enable = true;
+    rootless.enable = true;
+  };
+
+  # systemd-timesyncd
+  services.timesyncd.enable = true;
+
+  # Avahi
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true;
+    openFirewall = true;
+  };
+}


### PR DESCRIPTION
## Summary
- NixOS bare metal 構成を追加（WSL構成は共存）
-  配下に4つのモジュールを分割（責務ベース）
- Home Manager を NixOS module 経由で連携
- README に全構成の適用コマンドを明記

## Changes

### New Files
- `nixos/configuration.nix` — エントリポイント
- `nixos/hardware-configuration.nix` — ダミー（インストーラー生成で置き換え）
- `nixos/system/nix.nix` — nix settings, GC, Store optimise
- `nixos/system/hardware.nix` — AMD CPU/GPU, Mesa, Kernel, Bluetooth, Firmware
- `nixos/system/desktop.nix` — Hyprland, greetd, PipeWire, Locale, Fonts, Fcitx5
- `nixos/system/services.nix` — NetworkManager, Firewall, Docker, Avahi

### Modified
- `flake.nix` — `nixos-wsl` / `nixos` (bare metal) の2構成を並存、HM連携追加
- `ARCHITECTURE.md` — NixOSモジュール構成と責務を追記
- `README.md` — 全構成の利用方法を明記

## 設計方針
- 単一ホスト構成前提
- 責務でモジュールを分割（過度な分割は行わない）
- `isDesktop` は `user-options/options.nix` でホストごとに切替

## Test Plan
- [ ] PR diff をレビュー
- [ ] NixOS ホストで `nixos-rebuild test --flake .#nixos` が通る
- [ ] WSL構成 (`nixos-rebuild test --flake .#nixos-wsl`) が影響を受けていない