### PR TITLE
fix: ホスト構成を標準flake outputとして公開

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ NixOS + Home Manager + nix-darwin + chezmoi で Linux/macOS 環境を管理す�
 | nixos | Bare metal（単一ホスト） | `.#nixos` |
 | nixos-wsl | WSL2 on Windows | `.#nixos-wsl` |
 | mac-config | macOS（nix-darwin） | `.#mac-config` |
-| myHomeConfig | Home Manager 単体 | `.#myHomeConfig` |
+| myHomeConfig | Linux Home Manager 単体（x86_64） | `.#myHomeConfig` |
+| myHomeConfig-darwin | macOS Home Manager単体（Apple Silicon） | `.#myHomeConfig-darwin` |
+
+## セットアップの入口
+
+新しい端末では、dotfilesリポジトリのflake appからchezmoiを対話的に初期化する。
+
+```shell
+$ nix run github:himihiromu/dotfiles
+```
+
+chezmoiのLinuxセットアップスクリプトが`/etc/NIXOS`の有無を判定し、NixOSでは
+`nixosConfigurations.nixos`、それ以外では`homeConfigurations.myHomeConfig`を適用する。
+このリポジトリからchezmoiを呼び戻さず、セットアップ処理を一方向に保つ。
 
 ## NixOS (Bare Metal)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ NixOS + Home Manager + nix-darwin + chezmoi で Linux/macOS 環境を管理す�
 |--------|------|----------------|
 | nixos | Bare metal（単一ホスト） | `.#nixos` |
 | nixos-wsl | WSL2 on Windows | `.#nixos-wsl` |
-| mac-config | macOS（nix-darwin） | `.#mac-config` |
+| mac-config-aarch64 | macOS（nix-darwin、Apple Silicon） | `.#mac-config-aarch64` |
+| mac-config-x86_64 | macOS（nix-darwin、Intel） | `.#mac-config-x86_64` |
 | myHomeConfig | Linux Home Manager 単体（x86_64） | `.#myHomeConfig` |
-| myHomeConfig-darwin | macOS Home Manager単体（Apple Silicon） | `.#myHomeConfig-darwin` |
+| myHomeConfig-darwin-aarch64 | macOS Home Manager単体（Apple Silicon） | `.#myHomeConfig-darwin-aarch64` |
+| myHomeConfig-darwin-x86_64 | macOS Home Manager単体（Intel） | `.#myHomeConfig-darwin-x86_64` |
+
+互換性のため、既存の `mac-config` と `myHomeConfig-darwin` はApple Silicon向けの別名として残している。
 
 ## セットアップの入口
 
@@ -50,7 +54,11 @@ $ sudo nixos-rebuild switch --flake .#nixos-wsl
 ## nix-darwin (macOS)
 
 ```shell
-$ sudo nix run nix-darwin -- switch --flake .#mac-config
+# Apple Silicon
+$ sudo nix run nix-darwin -- switch --flake .#mac-config-aarch64
+
+# Intel
+$ sudo nix run nix-darwin -- switch --flake .#mac-config-x86_64
 ```
 
 ## Home Manager（単体）

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,27 @@
         "type": "github"
       }
     },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixvim-x86_64",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -92,6 +113,27 @@
       },
       "original": {
         "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager-x86_64": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-darwin-x86_64"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -166,6 +208,27 @@
         "type": "github"
       }
     },
+    "nix-darwin-x86_64": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-darwin-x86_64"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783744694,
+        "narHash": "sha256-2cp6N3rrwnGYLTx9l6N+NI+kwrCWxvJUbj5WJhvB29A=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "c3e90c89649b07d1a96e4b9dd6cd0d6e44b91a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "nix-darwin-26.05",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -198,6 +261,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin-x86_64": {
+      "locked": {
+        "lastModified": 1786367589,
+        "narHash": "sha256-OThVjKEZnNLw3eGBuxY644zKkmrDywlejQSZXR1vUUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4014d8bb312b04b49ec74adff5f9b32982bd0580",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -240,16 +319,43 @@
         "type": "github"
       }
     },
+    "nixvim-x86_64": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": [
+          "nixpkgs-darwin-x86_64"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1782919967,
+        "narHash": "sha256-pRwjfB5HQJ3m8J8bOR43pPHtHI7VUJSqwLA3P06cOY0=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "667c8471f4a0fb24d702d1a61af8609f1a5f1ba6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "nixos-26.05",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
+        "home-manager-x86_64": "home-manager-x86_64",
         "local-options": "local-options",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-darwin": "nix-darwin",
+        "nix-darwin-x86_64": "nix-darwin-x86_64",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-darwin-x86_64": "nixpkgs-darwin-x86_64",
         "nixvim": "nixvim",
+        "nixvim-x86_64": "nixvim-x86_64",
         "takt": "takt",
         "vim-src": "vim-src"
       }
@@ -281,6 +387,21 @@
       "original": {
         "owner": "nix-systems",
         "ref": "future-26.11",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
         "repo": "default",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -37,13 +37,22 @@
       flake = false;
     };
   };
-  outputs = { self, nixpkgs, nixos-wsl, neovim-nightly-overlay, flake-utils, home-manager, nix-darwin, nixvim, local-options, ... }@inputs:
-  flake-utils.lib.eachDefaultSystem (
-    system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixos-wsl,
+      neovim-nightly-overlay,
+      flake-utils,
+      home-manager,
+      nix-darwin,
+      nixvim,
+      local-options,
+      ...
+    }@inputs:
     let
       options = import local-options;
-      inherit (options) username;
-      inherit (options) isDesktop;
+      inherit (options) username isDesktop;
       rustCratesOverlay = final: prev: {
         keifu = prev.rustPlatform.buildRustPackage {
           pname = "keifu";
@@ -81,36 +90,194 @@
           cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
         };
       };
-      pkgs = (
+      mkPkgs =
+        system:
         (
-          (import nixpkgs {
-            inherit system;
-            config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
-              "zsh-abbr"
-              "claude-code"
-            ];
-          }).extend (
-            neovim-nightly-overlay.overlays.default
+          (
+            (import nixpkgs {
+              inherit system;
+              config.allowUnfreePredicate =
+                pkg:
+                builtins.elem (nixpkgs.lib.getName pkg) [
+                  "zsh-abbr"
+                  "claude-code"
+                ];
+            }).extend
+            (neovim-nightly-overlay.overlays.default)
           )
-        )
-      ).extend rustCratesOverlay;
+        ).extend
+          rustCratesOverlay;
     in
-    {
-      formatter = pkgs.nixfmt;
-      packages = {
-        my-package = pkgs.buildEnv {
-          name = "my-packages-list";
-          paths = with pkgs; [
-            git
-            curl
-            nixfmt
-            neovim
-          ];
+    (flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = mkPkgs system;
+      in
+      {
+        formatter = pkgs.nixfmt;
+        packages = {
+          my-package = pkgs.buildEnv {
+            name = "my-packages-list";
+            paths = with pkgs; [
+              git
+              curl
+              nixfmt
+              neovim
+            ];
+          };
         };
+        devShells = {
+          python = pkgs.mkShell {
+            buildInputs = [
+              pkgs.python314
+              pkgs.uv
+            ];
+            shellHook = ''
+              echo "uv version: $(uv --version)"
+              echo "python version: $(python --version)"
+            '';
+          };
+          js = pkgs.mkShell {
+            buildInputs = [
+              pkgs.nodejs_24
+              pkgs.pnpm
+              pkgs.bun
+              pkgs.yarn
+              pkgs.typescript-language-server
+              pkgs.typescript
+            ];
+            shellHook = ''
+              echo "node version: $(node --version)"
+              echo "npm version: $(npm --version)"
+              echo "pnpm version: $(pnpm --version)"
+              echo "bun version: $(bun --version)"
+              echo "yarn version: $(yarn --version)"
+            '';
+          };
+          java21 = pkgs.mkShell {
+            buildInputs = [
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-21
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(maven --version)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+            '';
+          };
+          java8 = pkgs.mkShell {
+            buildInputs = [
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-8
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(maven --version)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+            '';
+          };
+          go = pkgs.mkShell {
+            buildInputs = [
+              pkgs.go
+              pkgs.gotools
+              pkgs.golangci-lint
+            ];
+            shellHook = ''
+              echo "go version: $(go version)"
+              echo "golangci-lint version: $(golangci-lint --version)"
+              echo $GOPATH
+            '';
+          };
+          kotlin = pkgs.mkShell {
+            buildInputs = [
+              pkgs.kotlin
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-21
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(mvn -v)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+              echo "kotlin version: $(kotlin -version)"
+            '';
+          };
+          csharp = pkgs.mkShell {
+            buildInputs = [
+              pkgs.dotnet-sdk
+              pkgs.omnisharp-roslyn
+              # pkgs.dotnet-aspnetcore  # Web開発時に追加
+            ];
+            shellHook = ''
+              echo "dotnet version: $(dotnet --version)"
+              echo "OmniSharp version: $(omnisharp --version)"
+            '';
+          };
+        };
+        #   inherit system;
+        #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
+        # };
+        apps.update = {
+          type = "app";
+          program = toString (
+            pkgs.writeShellScript "update-script" ''
+              set -e
+              echo "Updating flake..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+              echo "Updating profile..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
+              echo "Update complete!"
+            ''
+          );
+        };
+        apps.install = {
+          type = "app";
+          program = toString (
+            pkgs.writeShellScript "update-script" ''
+              set -e
+              echo "Updating flake..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+              echo "Updating profile..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
+              echo "Update complete!"
+            ''
+          );
+        };
+      }
+    ))
+    // (
+      let
+        linuxSystem = "x86_64-linux";
+        darwinSystem = "aarch64-darwin";
+        linuxPkgs = mkPkgs linuxSystem;
+        darwinPkgs = mkPkgs darwinSystem;
+        mkHomeConfiguration =
+          system: pkgs:
+          home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              (import ./home-manager/default.nix {
+                inherit
+                  inputs
+                  username
+                  system
+                  isDesktop
+                  nixvim
+                  pkgs
+                  ;
+              })
+            ];
+          };
+      in
+      {
         nixosConfigurations = {
-          # WSL2 on Windows
           nixos-wsl = nixpkgs.lib.nixosSystem {
-            system = system;
+            system = linuxSystem;
             modules = [
               nixos-wsl.nixosModules.default
               {
@@ -119,180 +286,45 @@
               }
             ];
           };
-          # Bare metal (single host)
+
           nixos = nixpkgs.lib.nixosSystem {
-            system = system;
+            system = linuxSystem;
             modules = [
               { _module.args = { inherit username isDesktop; }; }
               ./nixos/configuration.nix
               home-manager.nixosModules.home-manager
               {
                 home-manager.users.${username} = import ./home-manager/default.nix {
-                  inherit inputs;
-                  inherit username;
-                  inherit pkgs;
-                  inherit system;
-                  inherit isDesktop;
-                  inherit nixvim;
+                  inherit
+                    inputs
+                    username
+                    isDesktop
+                    nixvim
+                    ;
+                  pkgs = linuxPkgs;
+                  system = linuxSystem;
                 };
               }
             ];
           };
         };
-        homeConfigurations = {
-          myHomeConfig = home-manager.lib.homeManagerConfiguration {
-            pkgs = pkgs;
 
-            modules = [
-              (import ./home-manager/default.nix {
-                inherit inputs;
-                inherit username;
-                inherit pkgs;
-                inherit system;
-                inherit isDesktop;
-                inherit nixvim;
-              })
-            ];
-          };
+        homeConfigurations = {
+          myHomeConfig = mkHomeConfiguration linuxSystem linuxPkgs;
+          myHomeConfig-darwin = mkHomeConfiguration darwinSystem darwinPkgs;
         };
-        darwinConfigurations = {
-          mac-config = nix-darwin.lib.darwinSystem {
-            system = system;
-            modules = [
-              { system.primaryUser = username; }
-              (import ./nix-darwin/default.nix {
-                inherit inputs;
-                inherit username;
-                inherit pkgs;
-                inherit system;
-                inherit isDesktop;
-              })
-            ];
-          };
-        };
-      };
-      devShells = {
-        python = pkgs.mkShell {
-          buildInputs = [
-            pkgs.python314
-            pkgs.uv
+
+        darwinConfigurations.mac-config = nix-darwin.lib.darwinSystem {
+          system = darwinSystem;
+          modules = [
+            { system.primaryUser = username; }
+            (import ./nix-darwin/default.nix {
+              inherit inputs username isDesktop;
+              pkgs = darwinPkgs;
+              system = darwinSystem;
+            })
           ];
-          shellHook = ''
-            echo "uv version: $(uv --version)"
-            echo "python version: $(python --version)"
-          '';
         };
-        js = pkgs.mkShell {
-          buildInputs = [
-            pkgs.nodejs_24
-            pkgs.pnpm
-            pkgs.bun
-            pkgs.yarn
-            pkgs.typescript-language-server
-            pkgs.typescript
-          ];
-          shellHook = ''
-            echo "node version: $(node --version)"
-            echo "npm version: $(npm --version)"
-            echo "pnpm version: $(pnpm --version)"
-            echo "bun version: $(bun --version)"
-            echo "yarn version: $(yarn --version)"
-          '';
-        };
-        java21 = pkgs.mkShell {
-          buildInputs = [
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-21
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(maven --version)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-          '';
-        };
-        java8 = pkgs.mkShell {
-          buildInputs = [
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-8
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(maven --version)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-          '';
-        };
-        go = pkgs.mkShell {
-          buildInputs = [
-            pkgs.go
-            pkgs.gotools
-            pkgs.golangci-lint
-          ];
-          shellHook = ''
-            echo "go version: $(go version)"
-            echo "golangci-lint version: $(golangci-lint --version)"
-            echo $GOPATH
-          '';
-        };
-        kotlin = pkgs.mkShell {
-          buildInputs = [
-            pkgs.kotlin
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-21
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(mvn -v)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-            echo "kotlin version: $(kotlin -version)"
-          '';
-        };
-        csharp = pkgs.mkShell {
-          buildInputs = [
-            pkgs.dotnet-sdk
-            pkgs.omnisharp-roslyn
-            # pkgs.dotnet-aspnetcore  # Web開発時に追加
-          ];
-          shellHook = ''
-            echo "dotnet version: $(dotnet --version)"
-            echo "OmniSharp version: $(omnisharp --version)"
-          '';
-        };
-      };
-      #   inherit system;
-      #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
-      # };
-      apps.update = {
-        type = "app";
-        program = toString (
-          pkgs.writeShellScript "update-script" ''
-            set -e
-            echo "Updating flake..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-            echo "Updating profile..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
-            echo "Update complete!"
-          ''
-        );
-      };
-      apps.install = {
-        type = "app";
-        program = toString (
-          pkgs.writeShellScript "update-script" ''
-            set -e
-            echo "Updating flake..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-            echo "Updating profile..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
-            echo "Update complete!"
-          ''
-        );
-      };
-    }
-  );
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # nixpkgs unstable no longer supports Intel macOS.
+    nixpkgs-darwin-x86_64.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
 
     vim-src = {
@@ -16,14 +18,26 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    home-manager-x86_64 = {
+      url = "github:nix-community/home-manager/release-26.05";
+      inputs.nixpkgs.follows = "nixpkgs-darwin-x86_64";
+    };
     nix-darwin = {
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-darwin-x86_64 = {
+      url = "github:LnL7/nix-darwin/nix-darwin-26.05";
+      inputs.nixpkgs.follows = "nixpkgs-darwin-x86_64";
     };
 
     nixvim = {
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixvim-x86_64 = {
+      url = "github:nix-community/nixvim/nixos-26.05";
+      inputs.nixpkgs.follows = "nixpkgs-darwin-x86_64";
     };
 
     takt = {
@@ -41,12 +55,16 @@
     {
       self,
       nixpkgs,
+      nixpkgs-darwin-x86_64,
       nixos-wsl,
       neovim-nightly-overlay,
       flake-utils,
       home-manager,
+      home-manager-x86_64,
       nix-darwin,
+      nix-darwin-x86_64,
       nixvim,
+      nixvim-x86_64,
       local-options,
       ...
     }@inputs:
@@ -90,15 +108,15 @@
           cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
         };
       };
-      mkPkgs =
-        system:
+      mkPkgsFor =
+        nixpkgsInput: system:
         (
           (
-            (import nixpkgs {
+            (import nixpkgsInput {
               inherit system;
               config.allowUnfreePredicate =
                 pkg:
-                builtins.elem (nixpkgs.lib.getName pkg) [
+                builtins.elem (nixpkgsInput.lib.getName pkg) [
                   "zsh-abbr"
                   "claude-code"
                 ];
@@ -107,6 +125,7 @@
           )
         ).extend
           rustCratesOverlay;
+      mkPkgs = mkPkgsFor nixpkgs;
     in
     (flake-utils.lib.eachDefaultSystem (
       system:
@@ -253,12 +272,15 @@
     // (
       let
         linuxSystem = "x86_64-linux";
-        darwinSystem = "aarch64-darwin";
+        darwinAarch64System = "aarch64-darwin";
+        darwinX86_64System = "x86_64-darwin";
         linuxPkgs = mkPkgs linuxSystem;
-        darwinPkgs = mkPkgs darwinSystem;
         mkHomeConfiguration =
-          system: pkgs:
-          home-manager.lib.homeManagerConfiguration {
+          nixpkgsInput: homeManagerInput: nixvimInput: system:
+          let
+            pkgs = mkPkgsFor nixpkgsInput system;
+          in
+          homeManagerInput.lib.homeManagerConfiguration {
             inherit pkgs;
             modules = [
               (import ./home-manager/default.nix {
@@ -267,12 +289,42 @@
                   username
                   system
                   isDesktop
-                  nixvim
                   pkgs
+                  ;
+                nixvim = nixvimInput;
+              })
+            ];
+          };
+        mkDarwinConfiguration =
+          nixpkgsInput: nixDarwinInput: system:
+          let
+            pkgs = mkPkgsFor nixpkgsInput system;
+          in
+          nixDarwinInput.lib.darwinSystem {
+            inherit system;
+            modules = [
+              { system.primaryUser = username; }
+              (import ./nix-darwin/default.nix {
+                inherit
+                  inputs
+                  username
+                  isDesktop
+                  pkgs
+                  system
                   ;
               })
             ];
           };
+        darwinAarch64HomeConfiguration =
+          mkHomeConfiguration nixpkgs home-manager nixvim
+            darwinAarch64System;
+        darwinX86_64HomeConfiguration =
+          mkHomeConfiguration nixpkgs-darwin-x86_64 home-manager-x86_64 nixvim-x86_64
+            darwinX86_64System;
+        darwinAarch64Configuration = mkDarwinConfiguration nixpkgs nix-darwin darwinAarch64System;
+        darwinX86_64Configuration =
+          mkDarwinConfiguration nixpkgs-darwin-x86_64 nix-darwin-x86_64
+            darwinX86_64System;
       in
       {
         nixosConfigurations = {
@@ -310,20 +362,20 @@
         };
 
         homeConfigurations = {
-          myHomeConfig = mkHomeConfiguration linuxSystem linuxPkgs;
-          myHomeConfig-darwin = mkHomeConfiguration darwinSystem darwinPkgs;
+          myHomeConfig = mkHomeConfiguration nixpkgs home-manager nixvim linuxSystem;
+          myHomeConfig-darwin-aarch64 = darwinAarch64HomeConfiguration;
+          myHomeConfig-darwin-x86_64 = darwinX86_64HomeConfiguration;
+
+          # Backward-compatible alias for the existing Apple Silicon entry point.
+          myHomeConfig-darwin = darwinAarch64HomeConfiguration;
         };
 
-        darwinConfigurations.mac-config = nix-darwin.lib.darwinSystem {
-          system = darwinSystem;
-          modules = [
-            { system.primaryUser = username; }
-            (import ./nix-darwin/default.nix {
-              inherit inputs username isDesktop;
-              pkgs = darwinPkgs;
-              system = darwinSystem;
-            })
-          ];
+        darwinConfigurations = {
+          mac-config-aarch64 = darwinAarch64Configuration;
+          mac-config-x86_64 = darwinX86_64Configuration;
+
+          # Backward-compatible alias for the existing Apple Silicon entry point.
+          mac-config = darwinAarch64Configuration;
         };
       }
     );


### PR DESCRIPTION
## 概要

chezmoiのセットアップスクリプトから参照できるよう、NixOS、Home Manager、nix-darwinの各構成を標準のトップレベルflake outputとして公開します。macOSについてはApple SiliconとIntelの構成を明示的に分離します。

## 変更内容

- `nixosConfigurations.nixos`と`nixosConfigurations.nixos-wsl`をトップレベルへ移動
- Linux用`homeConfigurations.myHomeConfig`をトップレベルへ移動
- macOS用Home Manager構成を`myHomeConfig-darwin-aarch64`と`myHomeConfig-darwin-x86_64`として公開
- nix-darwin構成を`mac-config-aarch64`と`mac-config-x86_64`として公開
- 既存の`myHomeConfig-darwin`と`mac-config`はApple Silicon向け互換エイリアスとして維持
- Intel macOS用にnixpkgs、Home Manager、nix-darwin、Nixvimの26.05系入力を分離
- chezmoiをセットアップの入口とする運用をREADMEへ追記
- NixOS/Home Manager側からchezmoiを呼び戻さない責務を明記

## 検証

- `homeConfigurations.myHomeConfig-darwin-aarch64`が`aarch64-darwin`として評価されることを確認
- `homeConfigurations.myHomeConfig-darwin-x86_64`が`x86_64-darwin`として評価されることを確認
- `darwinConfigurations.mac-config-aarch64`が`aarch64-darwin`として評価されることを確認
- `darwinConfigurations.mac-config-x86_64`が`x86_64-darwin`として評価されることを確認
- `git diff --check`

## 補足

Intel macOSはnixpkgs 26.05が最後の対応リリースのため、Intel構成のみ関連入力を26.05系に固定しています。

`nix flake check --impure --no-build`は既存のneovim-nightly overlayで、tree-sitterパッケージ関数に未対応の`wasmSupport`引数が渡るため停止します。今回変更したmacOS 4出力の個別評価は成功しています。
