### PR TITLE
feat: SteamとWindows共有ゲームライブラリを有効化

### DIFF
--- a/nixos/system/desktop.nix
+++ b/nixos/system/desktop.nix
@@ -1,6 +1,27 @@
-{ config, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
+  # Steam
+  nixpkgs.config.allowUnfreePredicate =
+    pkg:
+    builtins.elem (lib.getName pkg) [
+      "steam"
+      "steam-original"
+      "steam-unwrapped"
+      "steam-run"
+    ];
+
+  programs.steam = {
+    enable = true;
+    remotePlay.openFirewall = true;
+    dedicatedServer.openFirewall = true;
+  };
+
   # Hyprland
   programs.hyprland = {
     enable = true;

--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -1,6 +1,20 @@
 { config, pkgs, ... }:
 
 {
+  # Windows Steam library (J:). Keep Proton prefixes on the Linux filesystem.
+  fileSystems."/mnt/games" = {
+    device = "/dev/disk/by-uuid/1C7E75C67E7598EA";
+    fsType = "ntfs3";
+    options = [
+      "rw"
+      "uid=1000"
+      "gid=100"
+      "umask=0022"
+      "windows_names"
+      "noatime"
+    ];
+  };
+
   # UEFI boot loader (the generated hardware file only defines /boot).
   boot.loader = {
     systemd-boot = {

--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -3,7 +3,10 @@
 {
   # UEFI boot loader (the generated hardware file only defines /boot).
   boot.loader = {
-    systemd-boot.enable = true;
+    systemd-boot = {
+      enable = true;
+      configurationLimit = 3;
+    };
     efi.canTouchEfiVariables = true;
   };
 


### PR DESCRIPTION
## 概要

NixOSでSteamを有効化し、Windows 11のSteamライブラリをNTFSのまま共有できるようにします。

## 変更内容

- NixOSのSteamとRemote Play / Dedicated Server用firewall設定を有効化
- WindowsのSteamライブラリをUUID指定で`/mnt/games`へ`ntfs3` mount
- `uid=1000,gid=100,umask=0022`でSteamユーザーの書込みを許可
- `windows_names`でWindows非互換名の新規作成を防止
- `noatime`でNTFSへの不要な書込みを抑制
- systemd-bootの保持世代数を3に制限
- flake評価時の既定ユーザー名を再現可能に設定

Proton compatdataのBtrfs分離とSteam Library登録はホスト固有の初回セットアップとして実施し、Nix activationではNTFS上の状態を強制変更しません。

## 検証

- `nix eval`で`/mnt/games`のdevice、`ntfs3`、mount optionsを確認
- `nixos-rebuild build --flake .#nixos --no-write-lock-file`
- `git diff --check`
- `/mnt/games`が対象UUIDから`ntfs3,rw`でmountされることを確認
- Windows既存Steam LibraryをSteamが認識することを確認
- Proton prefixの実体がBtrfs上に生成されることを確認
- Sakuna: Of Rice and Ruinを標準Protonで起動確認

## 補足

`nix flake check --no-build`は既存のneovim-nightly-overlayとnixpkgs間の`wasmSupport`引数不整合で失敗します。対象のNixOS構成ビルドは成功しています。