### PR TITLE
feat: configure XBOOTLDR for BitLocker dual boot

### DIFF
--- a/nixos/hardware-configuration.nix
+++ b/nixos/hardware-configuration.nix
@@ -38,6 +38,15 @@
   };
 
   fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/4BA7-152C";
+    fsType = "vfat";
+    options = [
+      "fmask=0077"
+      "dmask=0077"
+    ];
+  };
+
+  fileSystems."/efi" = {
     device = "/dev/disk/by-uuid/6CF2-6803";
     fsType = "vfat";
     options = [

--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -15,13 +15,24 @@
     ];
   };
 
-  # UEFI boot loader (the generated hardware file only defines /boot).
+  # UEFI boot loader with separate XBOOTLDR and ESP partitions.
   boot.loader = {
+    grub.enable = false;
     systemd-boot = {
       enable = true;
       configurationLimit = 3;
+
+      # Kernel/initrd/boot entries are stored on the XBOOTLDR partition.
+      xbootldrMountPoint = "/boot";
+
+      # Reboot through the firmware Windows Boot Manager instead of
+      # directly chainloading Windows.
+      rebootForBitlocker = true;
     };
-    efi.canTouchEfiVariables = true;
+    efi = {
+      canTouchEfiVariables = true;
+      efiSysMountPoint = "/efi";
+    };
   };
 
   # AMD CPU Microcode


### PR DESCRIPTION
## 概要

BitLockerを利用するWindowsとのデュアルブート向けに、systemd-bootでXBOOTLDRとESPを分離して使用する構成へ変更します。

## 変更内容

- `/boot` にXBOOTLDRパーティションをマウント
- `/efi` にESPをマウント
- systemd-bootの`xbootldrMountPoint`とEFIのマウント先を明示
- `rebootForBitlocker`を有効化

## 検証

- `nix fmt nixos/hardware-configuration.nix nixos/system/hardware.nix`
- `nix eval --no-write-lock-file .#nixosConfigurations.nixos.config.system.build.toplevel.drvPath`
- `git diff --check`