### PR TITLE
fix(nixos): make games NTFS mount non-fatal

### DIFF
--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -12,6 +12,8 @@
       "umask=0022"
       "windows_names"
       "noatime"
+      "nofail"
+      "x-systemd.automount"
     ];
   };
 


### PR DESCRIPTION
## 発生していた問題

Windows 11 / NixOS で共有するゲーム用 NTFS パーティション `/mnt/games` が、NTFS の dirty flag により起動時に mount できず、`local-fs.target` が失敗して NixOS が Emergency Mode に入っていました。

## 変更内容

`/mnt/games` の既存 mount options に以下を追加しました。

- `nofail`: mount 失敗を `local-fs.target` の致命的な失敗にしない
- `x-systemd.automount`: 起動時ではなく `/mnt/games` へのアクセス時に mount を試行する

既存の `ntfs3`、read-write、所有権・マスク、`windows_names`、`noatime` の設定は維持しています。固定内蔵パーティションであり automount により起動時のデバイス待ちは発生しないため、device timeout は追加していません。ゲーム利用中の予期しない unmount を避けるため idle timeout も追加していません。

dirty / hibernated / 異常状態の NTFS に対する `force` は追加していません。安全側で mount を失敗させ、Windows 側での `chkdsk /f` や Fast Startup 無効化などの運用対応を前提とします。Windows 側の NTFS 修復自体はこの Nix 設定変更の対象外です。

## 検証

- `nix fmt nixos/system/hardware.nix`
- `git diff --check`
- `nix flake show --no-write-lock-file`
- `USER=himihiromu nix eval --impure --no-write-lock-file .#packages.x86_64-linux.nixosConfigurations.nixos.config.system.build.toplevel.drvPath`
- `USER=himihiromu nix build --impure --no-write-lock-file --no-link .#packages.x86_64-linux.nixosConfigurations.nixos.config.system.build.toplevel`
- 生成された `/etc/fstab` に `ntfs3 rw,uid=1000,gid=100,umask=0022,windows_names,noatime,nofail,x-systemd.automount` が含まれることを確認

稼働中ホストへの `nixos-rebuild switch` と、対象 NTFS への mount・修復・書き込みは実施していません。