### PR TITLE
feat(home-manager): install Heroic Games Launcher

### DIFF
--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -10,6 +10,9 @@
     # Browser
     chromium
 
+    # Game launcher
+    heroic
+
     # Clipboard
     clipse
     wl-clipboard


### PR DESCRIPTION
## Summary

- add Heroic Games Launcher to the Linux desktop packages

## Validation

- confirmed `heroic` is present in the evaluated Home Manager package list
- ran `git diff --check`