### PR TITLE
config: enable desktop profile

### DIFF
--- a/user-options/options.nix
+++ b/user-options/options.nix
@@ -1,7 +1,7 @@
 {
   # general
-  username = builtins.getEnv "USER";
-  isDesktop = false;
+  username = "himihiromu";
+  isDesktop = true;
 
   # git
   gitUsername = builtins.getEnv "GIT_USERNAME";


### PR DESCRIPTION
## Summary

- set the local username explicitly to `himihiromu`
- enable desktop-specific Home Manager configuration

## Validation

- evaluated the NixOS system toplevel derivation
- ran `git diff --check`