### PR TITLE
feat(waybar): add Bluetooth controls

### DIFF
--- a/home-manager/linux/waybar.nix
+++ b/home-manager/linux/waybar.nix
@@ -15,6 +15,7 @@
         modules-right = [
           "idle_inhibitor"
           "wireplumber"
+          "bluetooth"
           "network"
           "cpu"
           "memory"
@@ -52,6 +53,15 @@
           on-click-right = "pavucontrol";
           on-scroll-up = "wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+";
           on-scroll-down = "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-";
+        };
+        bluetooth = {
+          format = " {status}";
+          format-connected = " {device_alias}";
+          format-connected-battery = " {device_alias} {device_battery_percentage}%";
+          tooltip-format = "{controller_alias}\t{controller_address}\n\n{num_connections} connected";
+          tooltip-format-connected = "{controller_alias}\t{controller_address}\n\n{num_connections} connected\n\n{device_enumerate}";
+          tooltip-format-enumerate-connected = "{device_alias}\t{device_address}";
+          on-click = "blueman-manager";
         };
         network = {
           format-wifi = "{essid} ({signalStrength}%) ";

--- a/nixos/system/services.nix
+++ b/nixos/system/services.nix
@@ -19,6 +19,9 @@
   # Firmware updates
   services.fwupd.enable = true;
 
+  # Bluetooth device manager
+  services.blueman.enable = true;
+
   # Gaming mouse configuration daemon (libratbag)
   services.ratbagd.enable = true;
 


### PR DESCRIPTION
## Summary

- show Bluetooth status and connected device information in Waybar
- display battery percentage for supported Bluetooth devices
- open Blueman Manager when the Bluetooth module is clicked
- enable the NixOS Blueman service

## Validation

- evaluated the NixOS system toplevel derivation
- confirmed the generated Waybar configuration includes the Bluetooth module and `blueman-manager` click action
- ran `git diff --check`