### PR TITLE
fix(nixos): disable BitLocker reboot handling

### DIFF
--- a/nixos/system/hardware.nix
+++ b/nixos/system/hardware.nix
@@ -84,7 +84,7 @@
 
       # Reboot through the firmware Windows Boot Manager instead of
       # directly chainloading Windows.
-      rebootForBitlocker = true;
+      rebootForBitlocker = false;
     };
     efi = {
       canTouchEfiVariables = true;


### PR DESCRIPTION
## Summary

- disable systemd-boot BitLocker reboot handling
- allow the normal reboot path instead of routing through Windows Boot Manager

## Validation

- `nix eval --no-write-lock-file .#nixosConfigurations.nixos.config.system.build.toplevel.drvPath`
- `git diff --check -- nixos/system/hardware.nix`