### PR TITLE
feat(waybar): add status count modules

### DIFF
--- a/home-manager/linux/waybar.nix
+++ b/home-manager/linux/waybar.nix
@@ -1,4 +1,86 @@
-{ ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  notificationCount = pkgs.writeShellApplication {
+    name = "waybar-notification-count";
+    runtimeInputs = [ pkgs.swaynotificationcenter ];
+    text = ''
+      count="$(swaync-client --skip-wait --count 2>/dev/null || true)"
+
+      if [[ "$count" =~ ^[0-9]+$ ]] && (( count > 0 )); then
+        printf '%s\n' "$count"
+      fi
+    '';
+  };
+
+  dockerContainerCount = pkgs.writeShellApplication {
+    name = "waybar-docker-container-count";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.docker-client
+    ];
+    text = ''
+      containers="$(docker ps --quiet 2>/dev/null)" || exit 0
+
+      if [ -n "$containers" ]; then
+        printf '%s\n' "$containers" | wc --lines
+      fi
+    '';
+  };
+
+  nixUpdateCount = pkgs.writeShellApplication {
+    name = "waybar-nix-update-count";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.jq
+      pkgs.nix
+    ];
+    text = ''
+      flake_directory="${config.home.homeDirectory}/ghq/github.com/himihiromu/my-nix-package-control"
+
+      if [ ! -f "$flake_directory/flake.lock" ]; then
+        exit 0
+      fi
+
+      temporary_directory="$(mktemp --directory)"
+      trap 'rm -r -- "$temporary_directory"' EXIT
+      updated_lock="$temporary_directory/flake.lock"
+
+      if ! nix flake update \
+        --flake "$flake_directory" \
+        --output-lock-file "$updated_lock" \
+        >/dev/null 2>&1; then
+        exit 0
+      fi
+
+      count="$(
+        jq --null-input \
+          --slurpfile current "$flake_directory/flake.lock" \
+          --slurpfile updated "$updated_lock" \
+          '
+            $current[0].nodes as $currentNodes
+            | $updated[0].nodes as $updatedNodes
+            | [
+                $updatedNodes
+                | keys[] as $key
+                | select(
+                    $key != "root"
+                    and $updatedNodes[$key].locked != $currentNodes[$key].locked
+                  )
+              ]
+            | length
+          '
+      )"
+
+      if (( count > 0 )); then
+        printf '%s\n' "$count"
+      fi
+    '';
+  };
+in
 {
   programs.waybar = {
     enable = true;
@@ -20,6 +102,9 @@
           "cpu"
           "memory"
           "temperature"
+          "custom/nix-updates"
+          "custom/docker-containers"
+          "custom/notifications"
           "hyprland/language"
           "clock"
           "tray"
@@ -79,6 +164,28 @@
           input-filename = "temp1_input";
           critical-threshold = 80;
           format = "{temperatureC}°C ";
+        };
+        "custom/nix-updates" = {
+          exec = "${nixUpdateCount}/bin/waybar-nix-update-count";
+          interval = 21600;
+          format = " {}";
+          tooltip-format = "更新可能なflake入力: {}";
+          hide-empty-text = true;
+        };
+        "custom/docker-containers" = {
+          exec = "${dockerContainerCount}/bin/waybar-docker-container-count";
+          interval = 10;
+          format = " {}";
+          tooltip-format = "実行中のDockerコンテナ: {}";
+          hide-empty-text = true;
+        };
+        "custom/notifications" = {
+          exec = "${notificationCount}/bin/waybar-notification-count";
+          interval = 5;
+          format = " {}";
+          tooltip-format = "通知: {}";
+          hide-empty-text = true;
+          on-click = "${pkgs.swaynotificationcenter}/bin/swaync-client --toggle-panel";
         };
         clock = {
           tooltip-format = "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>";


### PR DESCRIPTION
## Summary

- show SwayNC notification count and toggle the notification panel on click
- show the number of running Docker containers
- show the number of updatable flake inputs without modifying `flake.lock`
- hide each custom module when its count is zero or unavailable

## Polling intervals

- notifications: 5 seconds
- Docker containers: 10 seconds
- Nix flake inputs: 6 hours

## Validation

- evaluated the Home Manager Waybar settings
- built `.#homeConfigurations.myHomeConfig.activationPackage`
- confirmed all generated scripts pass ShellCheck during the build
- executed all three generated scripts on NixOS
- confirmed the Nix update check leaves `flake.lock` unchanged
- ran `git diff --check -- home-manager/linux/waybar.nix`