### PR TITLE
feat(linux): add desktop GUI applications

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
               "zsh-abbr"
               "claude-code"
               "vscode"
+              "google-chrome"
             ];
           }).extend (
             neovim-nightly-overlay.overlays.default

--- a/flake.nix
+++ b/flake.nix
@@ -37,278 +37,263 @@
       flake = false;
     };
   };
-  outputs =
-    {
-      self,
-      nixpkgs,
-      nixos-wsl,
-      neovim-nightly-overlay,
-      flake-utils,
-      home-manager,
-      nix-darwin,
-      nixvim,
-      local-options,
-      ...
-    }@inputs:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        options = import local-options;
-        inherit (options) username;
-        inherit (options) isDesktop;
-        rustCratesOverlay = final: prev: {
-          keifu = prev.rustPlatform.buildRustPackage {
+  outputs = { self, nixpkgs, nixos-wsl, neovim-nightly-overlay, flake-utils, home-manager, nix-darwin, nixvim, local-options, ... }@inputs:
+  flake-utils.lib.eachDefaultSystem (
+    system:
+    let
+      options = import local-options;
+      inherit (options) username;
+      inherit (options) isDesktop;
+      rustCratesOverlay = final: prev: {
+        keifu = prev.rustPlatform.buildRustPackage {
+          pname = "keifu";
+          version = "0.1.5";
+
+          src = prev.fetchCrate {
             pname = "keifu";
             version = "0.1.5";
-
-            src = prev.fetchCrate {
-              pname = "keifu";
-              version = "0.1.5";
-              sha256 = "sha256-fo0c68H65/6GqOCQrkAEHvVssBL5n7ZL/XVcm4VIijo=";
-            };
-
-            cargoHash = "sha256-AyyLl9ZLMMikaeDvJhFXwAWgivi89gOqz52eyJZQTXQ=";
-
-            nativeBuildInputs = [ prev.pkg-config ];
-            buildInputs = [ prev.openssl ];
-
-            env = {
-              OPENSSL_NO_VENDOR = "1";
-              OPENSSL_DIR = "${prev.openssl.dev}";
-              OPENSSL_LIB_DIR = "${prev.openssl.out}/lib";
-              OPENSSL_INCLUDE_DIR = "${prev.openssl.dev}/include";
-            };
+            sha256 = "sha256-fo0c68H65/6GqOCQrkAEHvVssBL5n7ZL/XVcm4VIijo=";
           };
 
-          filetree = prev.rustPlatform.buildRustPackage {
-            pname = "filetree";
-            version = "0.3.5";
+          cargoHash = "sha256-AyyLl9ZLMMikaeDvJhFXwAWgivi89gOqz52eyJZQTXQ=";
 
-            src = prev.fetchCrate {
-              pname = "filetree";
-              version = "0.3.5";
-              sha256 = "sha256-27LsAG15Rr6Gbm/oL+tIeDrU/xa52bbEocPWInx8cl8=";
-            };
+          nativeBuildInputs = [ prev.pkg-config ];
+          buildInputs = [ prev.openssl ];
 
-            cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
+          env = {
+            OPENSSL_NO_VENDOR = "1";
+            OPENSSL_DIR = "${prev.openssl.dev}";
+            OPENSSL_LIB_DIR = "${prev.openssl.out}/lib";
+            OPENSSL_INCLUDE_DIR = "${prev.openssl.dev}/include";
           };
         };
-        pkgs =
-          (
-            (
-              (import nixpkgs {
-                inherit system;
-                config.allowUnfreePredicate =
-                  pkg:
-                  builtins.elem (nixpkgs.lib.getName pkg) [
-                    "zsh-abbr"
-                    "claude-code"
-                    "vscode"
-                  ];
-              }).extend
-              (neovim-nightly-overlay.overlays.default)
-            )
-          ).extend
-            rustCratesOverlay;
-      in
-      {
-        formatter = pkgs.nixfmt;
-        packages = {
-          my-package = pkgs.buildEnv {
-            name = "my-packages-list";
-            paths = with pkgs; [
-              git
-              curl
-              nixfmt
-              neovim
+
+        filetree = prev.rustPlatform.buildRustPackage {
+          pname = "filetree";
+          version = "0.3.5";
+
+          src = prev.fetchCrate {
+            pname = "filetree";
+            version = "0.3.5";
+            sha256 = "sha256-27LsAG15Rr6Gbm/oL+tIeDrU/xa52bbEocPWInx8cl8=";
+          };
+
+          cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
+        };
+      };
+      pkgs = (
+        (
+          (import nixpkgs {
+            inherit system;
+            config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+              "zsh-abbr"
+              "claude-code"
+              "vscode"
+            ];
+          }).extend (
+            neovim-nightly-overlay.overlays.default
+          )
+        )
+      ).extend rustCratesOverlay;
+    in
+    {
+      formatter = pkgs.nixfmt;
+      packages = {
+        my-package = pkgs.buildEnv {
+          name = "my-packages-list";
+          paths = with pkgs; [
+            git
+            curl
+            nixfmt
+            neovim
+          ];
+        };
+        nixosConfigurations = {
+          # WSL2 on Windows
+          nixos-wsl = nixpkgs.lib.nixosSystem {
+            system = system;
+            modules = [
+              nixos-wsl.nixosModules.default
+              {
+                system.stateVersion = "24.05";
+                wsl.enable = true;
+              }
             ];
           };
-          nixosConfigurations = {
-            # WSL2 on Windows
-            nixos-wsl = nixpkgs.lib.nixosSystem {
-              system = system;
-              modules = [
-                nixos-wsl.nixosModules.default
-                {
-                  system.stateVersion = "24.05";
-                  wsl.enable = true;
-                }
-              ];
-            };
-            # Bare metal (single host)
-            nixos = nixpkgs.lib.nixosSystem {
-              system = system;
-              modules = [
-                { _module.args = { inherit username isDesktop; }; }
-                ./nixos/configuration.nix
-                home-manager.nixosModules.home-manager
-                {
-                  home-manager.users.${username} = import ./home-manager/default.nix {
-                    inherit inputs;
-                    inherit username;
-                    inherit pkgs;
-                    inherit system;
-                    inherit isDesktop;
-                    inherit nixvim;
-                  };
-                }
-              ];
-            };
-          };
-          homeConfigurations = {
-            myHomeConfig = home-manager.lib.homeManagerConfiguration {
-              pkgs = pkgs;
-
-              modules = [
-                (import ./home-manager/default.nix {
+          # Bare metal (single host)
+          nixos = nixpkgs.lib.nixosSystem {
+            system = system;
+            modules = [
+              { _module.args = { inherit username isDesktop; }; }
+              ./nixos/configuration.nix
+              home-manager.nixosModules.home-manager
+              {
+                home-manager.users.${username} = import ./home-manager/default.nix {
                   inherit inputs;
                   inherit username;
                   inherit pkgs;
                   inherit system;
                   inherit isDesktop;
                   inherit nixvim;
-                })
-              ];
-            };
-          };
-          darwinConfigurations = {
-            mac-config = nix-darwin.lib.darwinSystem {
-              system = system;
-              modules = [
-                { system.primaryUser = username; }
-                (import ./nix-darwin/default.nix {
-                  inherit inputs;
-                  inherit username;
-                  inherit pkgs;
-                  inherit system;
-                  inherit isDesktop;
-                })
-              ];
-            };
+                };
+              }
+            ];
           };
         };
-        devShells = {
-          python = pkgs.mkShell {
-            buildInputs = [
-              pkgs.python314
-              pkgs.uv
+        homeConfigurations = {
+          myHomeConfig = home-manager.lib.homeManagerConfiguration {
+            pkgs = pkgs;
+
+            modules = [
+              (import ./home-manager/default.nix {
+                inherit inputs;
+                inherit username;
+                inherit pkgs;
+                inherit system;
+                inherit isDesktop;
+                inherit nixvim;
+              })
             ];
-            shellHook = ''
-              echo "uv version: $(uv --version)"
-              echo "python version: $(python --version)"
-            '';
-          };
-          js = pkgs.mkShell {
-            buildInputs = [
-              pkgs.nodejs_24
-              pkgs.pnpm
-              pkgs.bun
-              pkgs.yarn
-              pkgs.typescript-language-server
-              pkgs.typescript
-            ];
-            shellHook = ''
-              echo "node version: $(node --version)"
-              echo "npm version: $(npm --version)"
-              echo "pnpm version: $(pnpm --version)"
-              echo "bun version: $(bun --version)"
-              echo "yarn version: $(yarn --version)"
-            '';
-          };
-          java21 = pkgs.mkShell {
-            buildInputs = [
-              pkgs.gradle_9
-              pkgs.maven
-              pkgs.javaPackages.compiler.semeru-bin.jdk-21
-            ];
-            shellHook = ''
-              echo "gradle version: $(gradle --version)"
-              echo "maven version: $(maven --version)"
-              echo "java version: $(java --version)"
-              echo "javac version: $(javac --version)"
-            '';
-          };
-          java8 = pkgs.mkShell {
-            buildInputs = [
-              pkgs.gradle_9
-              pkgs.maven
-              pkgs.javaPackages.compiler.semeru-bin.jdk-8
-            ];
-            shellHook = ''
-              echo "gradle version: $(gradle --version)"
-              echo "maven version: $(maven --version)"
-              echo "java version: $(java --version)"
-              echo "javac version: $(javac --version)"
-            '';
-          };
-          go = pkgs.mkShell {
-            buildInputs = [
-              pkgs.go
-              pkgs.gotools
-              pkgs.golangci-lint
-            ];
-            shellHook = ''
-              echo "go version: $(go version)"
-              echo "golangci-lint version: $(golangci-lint --version)"
-              echo $GOPATH
-            '';
-          };
-          kotlin = pkgs.mkShell {
-            buildInputs = [
-              pkgs.kotlin
-              pkgs.gradle_9
-              pkgs.maven
-              pkgs.javaPackages.compiler.semeru-bin.jdk-21
-            ];
-            shellHook = ''
-              echo "gradle version: $(gradle --version)"
-              echo "maven version: $(mvn -v)"
-              echo "java version: $(java --version)"
-              echo "javac version: $(javac --version)"
-              echo "kotlin version: $(kotlin -version)"
-            '';
-          };
-          csharp = pkgs.mkShell {
-            buildInputs = [
-              pkgs.dotnet-sdk
-              pkgs.omnisharp-roslyn
-              # pkgs.dotnet-aspnetcore  # Web開発時に追加
-            ];
-            shellHook = ''
-              echo "dotnet version: $(dotnet --version)"
-              echo "OmniSharp version: $(omnisharp --version)"
-            '';
           };
         };
-        #   inherit system;
-        #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
-        # };
-        apps.update = {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "update-script" ''
-              set -e
-              echo "Updating flake..."
-              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-              echo "Updating profile..."
-              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
-              echo "Update complete!"
-            ''
-          );
+        darwinConfigurations = {
+          mac-config = nix-darwin.lib.darwinSystem {
+            system = system;
+            modules = [
+              { system.primaryUser = username; }
+              (import ./nix-darwin/default.nix {
+                inherit inputs;
+                inherit username;
+                inherit pkgs;
+                inherit system;
+                inherit isDesktop;
+              })
+            ];
+          };
         };
-        apps.install = {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "update-script" ''
-              set -e
-              echo "Updating flake..."
-              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-              echo "Updating profile..."
-              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
-              echo "Update complete!"
-            ''
-          );
+      };
+      devShells = {
+        python = pkgs.mkShell {
+          buildInputs = [
+            pkgs.python314
+            pkgs.uv
+          ];
+          shellHook = ''
+            echo "uv version: $(uv --version)"
+            echo "python version: $(python --version)"
+          '';
         };
-      }
-    );
+        js = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodejs_24
+            pkgs.pnpm
+            pkgs.bun
+            pkgs.yarn
+            pkgs.typescript-language-server
+            pkgs.typescript
+          ];
+          shellHook = ''
+            echo "node version: $(node --version)"
+            echo "npm version: $(npm --version)"
+            echo "pnpm version: $(pnpm --version)"
+            echo "bun version: $(bun --version)"
+            echo "yarn version: $(yarn --version)"
+          '';
+        };
+        java21 = pkgs.mkShell {
+          buildInputs = [
+            pkgs.gradle_9
+            pkgs.maven
+            pkgs.javaPackages.compiler.semeru-bin.jdk-21
+          ];
+          shellHook = ''
+            echo "gradle version: $(gradle --version)"
+            echo "maven version: $(maven --version)"
+            echo "java version: $(java --version)"
+            echo "javac version: $(javac --version)"
+          '';
+        };
+        java8 = pkgs.mkShell {
+          buildInputs = [
+            pkgs.gradle_9
+            pkgs.maven
+            pkgs.javaPackages.compiler.semeru-bin.jdk-8
+          ];
+          shellHook = ''
+            echo "gradle version: $(gradle --version)"
+            echo "maven version: $(maven --version)"
+            echo "java version: $(java --version)"
+            echo "javac version: $(javac --version)"
+          '';
+        };
+        go = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            pkgs.gotools
+            pkgs.golangci-lint
+          ];
+          shellHook = ''
+            echo "go version: $(go version)"
+            echo "golangci-lint version: $(golangci-lint --version)"
+            echo $GOPATH
+          '';
+        };
+        kotlin = pkgs.mkShell {
+          buildInputs = [
+            pkgs.kotlin
+            pkgs.gradle_9
+            pkgs.maven
+            pkgs.javaPackages.compiler.semeru-bin.jdk-21
+          ];
+          shellHook = ''
+            echo "gradle version: $(gradle --version)"
+            echo "maven version: $(mvn -v)"
+            echo "java version: $(java --version)"
+            echo "javac version: $(javac --version)"
+            echo "kotlin version: $(kotlin -version)"
+          '';
+        };
+        csharp = pkgs.mkShell {
+          buildInputs = [
+            pkgs.dotnet-sdk
+            pkgs.omnisharp-roslyn
+            # pkgs.dotnet-aspnetcore  # Web開発時に追加
+          ];
+          shellHook = ''
+            echo "dotnet version: $(dotnet --version)"
+            echo "OmniSharp version: $(omnisharp --version)"
+          '';
+        };
+      };
+      #   inherit system;
+      #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
+      # };
+      apps.update = {
+        type = "app";
+        program = toString (
+          pkgs.writeShellScript "update-script" ''
+            set -e
+            echo "Updating flake..."
+            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+            echo "Updating profile..."
+            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
+            echo "Update complete!"
+          ''
+        );
+      };
+      apps.install = {
+        type = "app";
+        program = toString (
+          pkgs.writeShellScript "update-script" ''
+            set -e
+            echo "Updating flake..."
+            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+            echo "Updating profile..."
+            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
+            echo "Update complete!"
+          ''
+        );
+      };
+    }
+  );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,262 +37,278 @@
       flake = false;
     };
   };
-  outputs = { self, nixpkgs, nixos-wsl, neovim-nightly-overlay, flake-utils, home-manager, nix-darwin, nixvim, local-options, ... }@inputs:
-  flake-utils.lib.eachDefaultSystem (
-    system:
-    let
-      options = import local-options;
-      inherit (options) username;
-      inherit (options) isDesktop;
-      rustCratesOverlay = final: prev: {
-        keifu = prev.rustPlatform.buildRustPackage {
-          pname = "keifu";
-          version = "0.1.5";
-
-          src = prev.fetchCrate {
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixos-wsl,
+      neovim-nightly-overlay,
+      flake-utils,
+      home-manager,
+      nix-darwin,
+      nixvim,
+      local-options,
+      ...
+    }@inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        options = import local-options;
+        inherit (options) username;
+        inherit (options) isDesktop;
+        rustCratesOverlay = final: prev: {
+          keifu = prev.rustPlatform.buildRustPackage {
             pname = "keifu";
             version = "0.1.5";
-            sha256 = "sha256-fo0c68H65/6GqOCQrkAEHvVssBL5n7ZL/XVcm4VIijo=";
+
+            src = prev.fetchCrate {
+              pname = "keifu";
+              version = "0.1.5";
+              sha256 = "sha256-fo0c68H65/6GqOCQrkAEHvVssBL5n7ZL/XVcm4VIijo=";
+            };
+
+            cargoHash = "sha256-AyyLl9ZLMMikaeDvJhFXwAWgivi89gOqz52eyJZQTXQ=";
+
+            nativeBuildInputs = [ prev.pkg-config ];
+            buildInputs = [ prev.openssl ];
+
+            env = {
+              OPENSSL_NO_VENDOR = "1";
+              OPENSSL_DIR = "${prev.openssl.dev}";
+              OPENSSL_LIB_DIR = "${prev.openssl.out}/lib";
+              OPENSSL_INCLUDE_DIR = "${prev.openssl.dev}/include";
+            };
           };
 
-          cargoHash = "sha256-AyyLl9ZLMMikaeDvJhFXwAWgivi89gOqz52eyJZQTXQ=";
-
-          nativeBuildInputs = [ prev.pkg-config ];
-          buildInputs = [ prev.openssl ];
-
-          env = {
-            OPENSSL_NO_VENDOR = "1";
-            OPENSSL_DIR = "${prev.openssl.dev}";
-            OPENSSL_LIB_DIR = "${prev.openssl.out}/lib";
-            OPENSSL_INCLUDE_DIR = "${prev.openssl.dev}/include";
-          };
-        };
-
-        filetree = prev.rustPlatform.buildRustPackage {
-          pname = "filetree";
-          version = "0.3.5";
-
-          src = prev.fetchCrate {
+          filetree = prev.rustPlatform.buildRustPackage {
             pname = "filetree";
             version = "0.3.5";
-            sha256 = "sha256-27LsAG15Rr6Gbm/oL+tIeDrU/xa52bbEocPWInx8cl8=";
-          };
 
-          cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
+            src = prev.fetchCrate {
+              pname = "filetree";
+              version = "0.3.5";
+              sha256 = "sha256-27LsAG15Rr6Gbm/oL+tIeDrU/xa52bbEocPWInx8cl8=";
+            };
+
+            cargoHash = "sha256-TZWIa4L70WpvGwTi8DIadKwXEubxn3OciSaWf9UULZA=";
+          };
         };
-      };
-      pkgs = (
-        (
-          (import nixpkgs {
-            inherit system;
-            config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
-              "zsh-abbr"
-              "claude-code"
-            ];
-          }).extend (
-            neovim-nightly-overlay.overlays.default
-          )
-        )
-      ).extend rustCratesOverlay;
-    in
-    {
-      formatter = pkgs.nixfmt;
-      packages = {
-        my-package = pkgs.buildEnv {
-          name = "my-packages-list";
-          paths = with pkgs; [
-            git
-            curl
-            nixfmt
-            neovim
-          ];
-        };
-        nixosConfigurations = {
-          # WSL2 on Windows
-          nixos-wsl = nixpkgs.lib.nixosSystem {
-            system = system;
-            modules = [
-              nixos-wsl.nixosModules.default
-              {
-                system.stateVersion = "24.05";
-                wsl.enable = true;
-              }
+        pkgs =
+          (
+            (
+              (import nixpkgs {
+                inherit system;
+                config.allowUnfreePredicate =
+                  pkg:
+                  builtins.elem (nixpkgs.lib.getName pkg) [
+                    "zsh-abbr"
+                    "claude-code"
+                    "vscode"
+                  ];
+              }).extend
+              (neovim-nightly-overlay.overlays.default)
+            )
+          ).extend
+            rustCratesOverlay;
+      in
+      {
+        formatter = pkgs.nixfmt;
+        packages = {
+          my-package = pkgs.buildEnv {
+            name = "my-packages-list";
+            paths = with pkgs; [
+              git
+              curl
+              nixfmt
+              neovim
             ];
           };
-          # Bare metal (single host)
-          nixos = nixpkgs.lib.nixosSystem {
-            system = system;
-            modules = [
-              { _module.args = { inherit username isDesktop; }; }
-              ./nixos/configuration.nix
-              home-manager.nixosModules.home-manager
-              {
-                home-manager.users.${username} = import ./home-manager/default.nix {
+          nixosConfigurations = {
+            # WSL2 on Windows
+            nixos-wsl = nixpkgs.lib.nixosSystem {
+              system = system;
+              modules = [
+                nixos-wsl.nixosModules.default
+                {
+                  system.stateVersion = "24.05";
+                  wsl.enable = true;
+                }
+              ];
+            };
+            # Bare metal (single host)
+            nixos = nixpkgs.lib.nixosSystem {
+              system = system;
+              modules = [
+                { _module.args = { inherit username isDesktop; }; }
+                ./nixos/configuration.nix
+                home-manager.nixosModules.home-manager
+                {
+                  home-manager.users.${username} = import ./home-manager/default.nix {
+                    inherit inputs;
+                    inherit username;
+                    inherit pkgs;
+                    inherit system;
+                    inherit isDesktop;
+                    inherit nixvim;
+                  };
+                }
+              ];
+            };
+          };
+          homeConfigurations = {
+            myHomeConfig = home-manager.lib.homeManagerConfiguration {
+              pkgs = pkgs;
+
+              modules = [
+                (import ./home-manager/default.nix {
                   inherit inputs;
                   inherit username;
                   inherit pkgs;
                   inherit system;
                   inherit isDesktop;
                   inherit nixvim;
-                };
-              }
-            ];
+                })
+              ];
+            };
+          };
+          darwinConfigurations = {
+            mac-config = nix-darwin.lib.darwinSystem {
+              system = system;
+              modules = [
+                { system.primaryUser = username; }
+                (import ./nix-darwin/default.nix {
+                  inherit inputs;
+                  inherit username;
+                  inherit pkgs;
+                  inherit system;
+                  inherit isDesktop;
+                })
+              ];
+            };
           };
         };
-        homeConfigurations = {
-          myHomeConfig = home-manager.lib.homeManagerConfiguration {
-            pkgs = pkgs;
-
-            modules = [
-              (import ./home-manager/default.nix {
-                inherit inputs;
-                inherit username;
-                inherit pkgs;
-                inherit system;
-                inherit isDesktop;
-                inherit nixvim;
-              })
+        devShells = {
+          python = pkgs.mkShell {
+            buildInputs = [
+              pkgs.python314
+              pkgs.uv
             ];
+            shellHook = ''
+              echo "uv version: $(uv --version)"
+              echo "python version: $(python --version)"
+            '';
+          };
+          js = pkgs.mkShell {
+            buildInputs = [
+              pkgs.nodejs_24
+              pkgs.pnpm
+              pkgs.bun
+              pkgs.yarn
+              pkgs.typescript-language-server
+              pkgs.typescript
+            ];
+            shellHook = ''
+              echo "node version: $(node --version)"
+              echo "npm version: $(npm --version)"
+              echo "pnpm version: $(pnpm --version)"
+              echo "bun version: $(bun --version)"
+              echo "yarn version: $(yarn --version)"
+            '';
+          };
+          java21 = pkgs.mkShell {
+            buildInputs = [
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-21
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(maven --version)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+            '';
+          };
+          java8 = pkgs.mkShell {
+            buildInputs = [
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-8
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(maven --version)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+            '';
+          };
+          go = pkgs.mkShell {
+            buildInputs = [
+              pkgs.go
+              pkgs.gotools
+              pkgs.golangci-lint
+            ];
+            shellHook = ''
+              echo "go version: $(go version)"
+              echo "golangci-lint version: $(golangci-lint --version)"
+              echo $GOPATH
+            '';
+          };
+          kotlin = pkgs.mkShell {
+            buildInputs = [
+              pkgs.kotlin
+              pkgs.gradle_9
+              pkgs.maven
+              pkgs.javaPackages.compiler.semeru-bin.jdk-21
+            ];
+            shellHook = ''
+              echo "gradle version: $(gradle --version)"
+              echo "maven version: $(mvn -v)"
+              echo "java version: $(java --version)"
+              echo "javac version: $(javac --version)"
+              echo "kotlin version: $(kotlin -version)"
+            '';
+          };
+          csharp = pkgs.mkShell {
+            buildInputs = [
+              pkgs.dotnet-sdk
+              pkgs.omnisharp-roslyn
+              # pkgs.dotnet-aspnetcore  # Web開発時に追加
+            ];
+            shellHook = ''
+              echo "dotnet version: $(dotnet --version)"
+              echo "OmniSharp version: $(omnisharp --version)"
+            '';
           };
         };
-        darwinConfigurations = {
-          mac-config = nix-darwin.lib.darwinSystem {
-            system = system;
-            modules = [
-              { system.primaryUser = username; }
-              (import ./nix-darwin/default.nix {
-                inherit inputs;
-                inherit username;
-                inherit pkgs;
-                inherit system;
-                inherit isDesktop;
-              })
-            ];
-          };
+        #   inherit system;
+        #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
+        # };
+        apps.update = {
+          type = "app";
+          program = toString (
+            pkgs.writeShellScript "update-script" ''
+              set -e
+              echo "Updating flake..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+              echo "Updating profile..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
+              echo "Update complete!"
+            ''
+          );
         };
-      };
-      devShells = {
-        python = pkgs.mkShell {
-          buildInputs = [
-            pkgs.python314
-            pkgs.uv
-          ];
-          shellHook = ''
-            echo "uv version: $(uv --version)"
-            echo "python version: $(python --version)"
-          '';
+        apps.install = {
+          type = "app";
+          program = toString (
+            pkgs.writeShellScript "update-script" ''
+              set -e
+              echo "Updating flake..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
+              echo "Updating profile..."
+              nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
+              echo "Update complete!"
+            ''
+          );
         };
-        js = pkgs.mkShell {
-          buildInputs = [
-            pkgs.nodejs_24
-            pkgs.pnpm
-            pkgs.bun
-            pkgs.yarn
-            pkgs.typescript-language-server
-            pkgs.typescript
-          ];
-          shellHook = ''
-            echo "node version: $(node --version)"
-            echo "npm version: $(npm --version)"
-            echo "pnpm version: $(pnpm --version)"
-            echo "bun version: $(bun --version)"
-            echo "yarn version: $(yarn --version)"
-          '';
-        };
-        java21 = pkgs.mkShell {
-          buildInputs = [
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-21
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(maven --version)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-          '';
-        };
-        java8 = pkgs.mkShell {
-          buildInputs = [
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-8
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(maven --version)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-          '';
-        };
-        go = pkgs.mkShell {
-          buildInputs = [
-            pkgs.go
-            pkgs.gotools
-            pkgs.golangci-lint
-          ];
-          shellHook = ''
-            echo "go version: $(go version)"
-            echo "golangci-lint version: $(golangci-lint --version)"
-            echo $GOPATH
-          '';
-        };
-        kotlin = pkgs.mkShell {
-          buildInputs = [
-            pkgs.kotlin
-            pkgs.gradle_9
-            pkgs.maven
-            pkgs.javaPackages.compiler.semeru-bin.jdk-21
-          ];
-          shellHook = ''
-            echo "gradle version: $(gradle --version)"
-            echo "maven version: $(mvn -v)"
-            echo "java version: $(java --version)"
-            echo "javac version: $(javac --version)"
-            echo "kotlin version: $(kotlin -version)"
-          '';
-        };
-        csharp = pkgs.mkShell {
-          buildInputs = [
-            pkgs.dotnet-sdk
-            pkgs.omnisharp-roslyn
-            # pkgs.dotnet-aspnetcore  # Web開発時に追加
-          ];
-          shellHook = ''
-            echo "dotnet version: $(dotnet --version)"
-            echo "OmniSharp version: $(omnisharp --version)"
-          '';
-        };
-      };
-      #   inherit system;
-      #   modules = [ home-manager.darwinModules.home-manager ./nix-darwin/default.nix ];
-      # };
-      apps.update = {
-        type = "app";
-        program = toString (
-          pkgs.writeShellScript "update-script" ''
-            set -e
-            echo "Updating flake..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-            echo "Updating profile..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile upgrade my-packages
-            echo "Update complete!"
-          ''
-        );
-      };
-      apps.install = {
-        type = "app";
-        program = toString (
-          pkgs.writeShellScript "update-script" ''
-            set -e
-            echo "Updating flake..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update
-            echo "Updating profile..."
-            nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install my-packages
-            echo "Update complete!"
-          ''
-        );
-      };
-    }
-  );
+      }
+    );
 }

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -13,6 +13,10 @@
     floorp-bin
     google-chrome
 
+    # Mail
+    geary
+    thunderbird
+
     # Editor
     vscode
 

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -10,6 +10,9 @@
     # Browser
     chromium
 
+    # Editor
+    vscode
+
     # Game launcher
     heroic
 

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -17,6 +17,13 @@
     geary
     thunderbird
 
+    # Photos
+    gthumb
+
+    # Image editing
+    gimp
+    krita
+
     # Editor
     vscode
 

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -11,6 +11,7 @@
     chromium
     firefox
     floorp-bin
+    google-chrome
 
     # Editor
     vscode

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -20,6 +20,12 @@
     # File Manager
     nemo
 
+    # File sharing
+    localsend
+
+    # System monitor
+    mission-center
+
     # Wallpaper
     waypaper
 

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -9,6 +9,8 @@
 
     # Browser
     chromium
+    firefox
+    floorp-bin
 
     # Editor
     vscode

--- a/nixos/system/services.nix
+++ b/nixos/system/services.nix
@@ -5,7 +5,11 @@
   networking.networkmanager.enable = true;
 
   # Firewall
-  networking.firewall.enable = true;
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 53317 ];
+    allowedUDPPorts = [ 53317 ];
+  };
 
   # Docker
   virtualisation.docker = {


### PR DESCRIPTION
## Summary

- add LocalSend for local cross-platform file sharing
- add Mission Center for graphical system resource monitoring
- add Microsoft Visual Studio Code and allow its unfree package explicitly
- add Firefox, Floorp, and Google Chrome browsers
- add Geary and Thunderbird mail clients
- add gThumb for photo viewing and management
- add GIMP and Krita for image editing
- allow Google Chrome as an unfree package explicitly
- allow inbound TCP and UDP traffic on port 53317 for LocalSend device discovery and transfers

## Validation

- confirmed all added applications are included in the evaluated Home Manager package list
- confirmed TCP and UDP port 53317 are included in the evaluated firewall configuration
- built `.#nixosConfigurations.nixos.config.system.build.toplevel`
- ran `git diff --check`