### PR TITLE
feat(linux): install ChatGPT desktop app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
               "claude-code"
               "vscode"
               "google-chrome"
+              "chatgpt"
             ];
           }).extend (
             neovim-nightly-overlay.overlays.default

--- a/home-manager/linux/chatgpt.nix
+++ b/home-manager/linux/chatgpt.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libnotify,
+  libusb1,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  xdg-utils,
+  git,
+}:
+
+stdenv.mkDerivation {
+  pname = "chatgpt";
+  version = "26.814.41957";
+
+  src = fetchurl {
+    url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
+    hash = "sha256-R3iyanq9CGRyFNWwXBe9Pr4tlojRRtq/AXwaL6+TrH0=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libnotify
+    libusb1
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxkbcommon
+    libxrandr
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    systemd
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libQt5Core.so.5"
+    "libQt5Gui.so.5"
+    "libQt5Widgets.so.5"
+    "libQt6Core.so.6"
+    "libQt6Gui.so.6"
+    "libQt6Widgets.so.6"
+    "libc.musl-x86_64.so.1"
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb --extract "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib" "$out/share"
+    cp -r usr/lib/chatgpt "$out/lib/"
+    cp -r usr/share/applications usr/share/pixmaps "$out/share/"
+    ln -s "$out/lib/chatgpt/codex-launcher" "$out/bin/chatgpt"
+
+    wrapProgram "$out/lib/chatgpt/ChatGPT" \
+      --prefix PATH : ${lib.makeBinPath [ git xdg-utils ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ChatGPT desktop app by OpenAI";
+    homepage = "https://learn.chatgpt.com/docs/linux/linux-app";
+    license = lib.licenses.unfree;
+    mainProgram = "chatgpt";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/home-manager/linux/desktop.nix
+++ b/home-manager/linux/desktop.nix
@@ -1,4 +1,7 @@
 { pkgs }:
+let
+  chatgpt = pkgs.callPackage ./chatgpt.nix { };
+in
 {
   installPackages = with pkgs; [
     # Terminal
@@ -12,6 +15,9 @@
     firefox
     floorp-bin
     google-chrome
+
+    # AI assistant
+    chatgpt
 
     # Mail
     geary


### PR DESCRIPTION
## Summary

- package the official ChatGPT Linux x64 Debian artifact for NixOS
- patch required runtime libraries and preserve the upstream desktop entry and icon
- install ChatGPT through the Linux Home Manager package list
- allow the unfree ChatGPT package

## Validation

- built the complete Home Manager activation package
- confirmed the wrapped ELF has no unresolved dynamic libraries
- confirmed the desktop entry and icon are installed
- confirmed chatgpt --version reports 26.814.41957
- ran git diff --check

## Notes

The official Linux app is currently a preview for Ubuntu, Debian, and Fedora. NixOS is not an officially supported distribution, so this wrapper is best effort. The source URL follows the upstream latest artifact while the fixed hash keeps builds reproducible and makes upstream updates explicit.